### PR TITLE
dci-workshop paragraph overflow

### DIFF
--- a/dci-workshop/index.html
+++ b/dci-workshop/index.html
@@ -14,7 +14,7 @@ title: "DCI Workshop"
         <a href="https://facebook.com/dciets">Suivez-nous sur Facebook</a> pour être au courant de la prochaine édition.
       </p>
     </div>
-    <div class="col-md-8 col-md-pull-4 posts">
+    <div class="col-md-8 col-md-pull-4">
       {% for post in site.categories.dci-workshop %}
       <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
       {{ post.excerpt}}


### PR DESCRIPTION
L'ordre des colonnes étaient inversé ce qui faisait que vous deviez pull/push les colonnes pour rien.
La classe .posts cachait l'overflow + ajoutait un no-wrap sur le div ce qui faisait overflow le text et le cachait.

@Becojo 