### PR TITLE
Add missing link for x86 instruction set listing

### DIFF
--- a/dci-workshop/_posts/2020-01-29-Introduction à la rétro-ingénierie.markdown
+++ b/dci-workshop/_posts/2020-01-29-Introduction à la rétro-ingénierie.markdown
@@ -14,6 +14,7 @@ Vous serez introduits au fonctionnement de IDA, à la lecture du code assembleur
 Sections pertinentes pour le workshop: Toutes sauf celle sur l'analyse dynamique.
 
 - [Slides (La Bible)](https://drive.google.com/open?id=106nACTbg7OIj121vzbzWTZUV2m758Ug5)
+- [Instructions en assembleur Intel x86_64](https://www.felixcloutier.com/x86/)
 
 ## Outil
 


### PR DESCRIPTION
A link for the reverse engineering workshop that I kept forgetting to commit. 